### PR TITLE
Added fill on layoutSizingHorizontal to column auto layout

### DIFF
--- a/src/main/code.ts
+++ b/src/main/code.ts
@@ -31,6 +31,7 @@ if (figma.command == "generate-table") {
 					selection[0] as FrameNode,
 					msg.wrap_in_autolayout,
 					msg.right_align_numbers,
+					msg.set_column_fill,
 					msg.data)
 				figma.currentPage.selection = headerCells;
 				figma.closePlugin();
@@ -101,6 +102,7 @@ function createTable(
 	original: FrameNode,
 	wrapInAutoLayout: boolean,
 	right_align_numbers: boolean,
+	setColumnFill: boolean,
 	data: String,
 ) {
 	var columnAutoLayouts: FrameNode[];
@@ -128,14 +130,16 @@ function createTable(
 			var columns = line.split("\t")
 			for (var j = 0; j < columns.length; j++) {
 				if (wrapInAutoLayout && i == 0) {
-					table.minWidth = original.width * columns.length
 					var columnAutoLayout = figma.createFrame()
 					columnAutoLayout.fills = []
 					columnAutoLayout.layoutMode = 'VERTICAL'
 					columnAutoLayouts.push(columnAutoLayout)
 					columnAutoLayout.name = 'Column ' + j
 					table.appendChild(columnAutoLayout)
-					columnAutoLayout.layoutSizingHorizontal = 'FILL'
+					if (setColumnFill) {
+						table.minWidth = original.width * columns.length
+						columnAutoLayout.layoutSizingHorizontal = 'FILL'
+					}
 				}
 
 				var newNode: FrameNode = original.clone()

--- a/src/main/code.ts
+++ b/src/main/code.ts
@@ -19,7 +19,7 @@ if (figma.command == "generate-table") {
 		figma.closePlugin("🛑 Selected node must be an instance of a component");
 	} else {
 		// This shows the HTML page in "ui.html".
-		figma.showUI(__html__, { width: 300, height: 366, title: "Table Builder" });
+		figma.showUI(__html__, { width: 300, height: 400, title: "Table Builder" });
 	}
 
 	figma.ui.onmessage = msg => {
@@ -157,9 +157,6 @@ function createTable(
 				}
 
 				if (wrapInAutoLayout) {
-					textNode.layoutSizingVertical = 'FIXED'
-					textNode.layoutSizingHorizontal = 'FIXED'
-					textNode.layoutSizingHorizontal = 'HUG'
 					columnAutoLayouts[j].appendChild(newNode)
 					columnAutoLayouts[j].counterAxisSizingMode = 'AUTO'
 				} else {

--- a/src/main/code.ts
+++ b/src/main/code.ts
@@ -128,12 +128,14 @@ function createTable(
 			var columns = line.split("\t")
 			for (var j = 0; j < columns.length; j++) {
 				if (wrapInAutoLayout && i == 0) {
+					table.minWidth = original.width * columns.length
 					var columnAutoLayout = figma.createFrame()
 					columnAutoLayout.fills = []
 					columnAutoLayout.layoutMode = 'VERTICAL'
 					columnAutoLayouts.push(columnAutoLayout)
 					columnAutoLayout.name = 'Column ' + j
 					table.appendChild(columnAutoLayout)
+					columnAutoLayout.layoutSizingHorizontal = 'FILL'
 				}
 
 				var newNode: FrameNode = original.clone()

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -22,6 +22,11 @@
         <input type="checkbox" id="right_align_numbers" name="right_align_numbers" checked="checked">
         <label for="right_align_numbers" class="type--bold type--small"> Align numeric values to the right</label><br>
 
+        <div id="set_column_fill_div">
+            <input type="checkbox" id="set_column_fill" name="set_column_fill">
+            <label for="set_column_fill" class="type--bold type--small"> Set column resizing to fill</label><br>
+        </div>
+
         <div class="btn-group">
             <button id="cancel" class='button button--secondary'>Cancel</button>
             <button id="run" class='button button--primary'>Generate table</button> 
@@ -34,6 +39,7 @@
                 data: document.getElementById('data').value,
                 wrap_in_autolayout: document.getElementById('wrap_in_autolayout').checked,
                 right_align_numbers: document.getElementById('right_align_numbers').checked,
+                set_column_fill: document.getElementById('set_column_fill').checked,
             } }, '*')
             }
             
@@ -46,6 +52,7 @@
             onmessage = (event) => {
                 document.getElementById('run').textContent = "Update table"
                 document.getElementById('wrap_in_autolayout_div').hidden = true
+                document.getElementById('set_column_fill_div').hidden = true
             }
         </script>
 


### PR DESCRIPTION
When you create a table starting from a cell component, the result is not responsive when resized to fill the horizontal space. This is due to the fact that the column auto layout has layoutSizingHorizontal set to 'hug'

Here an example with the old version:
![table-builder-old](https://github.com/ergon/figma-table-builder/assets/7292153/871ee2d9-0f14-4138-b294-b8c56d7db00d)

Here is an example with the new version:
![table-builder-new](https://github.com/ergon/figma-table-builder/assets/7292153/d4208538-8a0a-45b2-ab3d-077d50184014)

In the new version, I've changed the layoutSizingHorizontal to 'Fill' and set the table minWidth to the cell's width multiplied for the number of columns inserted by the user, so that the resulting table will have the perfect size to contain all the new cells